### PR TITLE
refactor: used cors and deleted body-parser

### DIFF
--- a/mock-server/index.js
+++ b/mock-server/index.js
@@ -1,9 +1,17 @@
-const express = require("express");
-const bodyParser = require("body-parser");
-const mockApi = require("./API/mockApi");
+const cors = require('cors');
+const express = require('express');
+const mockApi = require('./API/mockApi');
 
 var app = express();
-app.use(bodyParser.json());
+app.use(
+  cors({
+    origin: 'http://localhost:3000',
+    credentials: true,
+  })
+);
+app.use(express.json());
 const serverPort = 4000;
-app.listen(serverPort, () => console.log(`server started successfully at port ${serverPort}....`));
-app.use("/", mockApi);
+app.listen(serverPort, () =>
+  console.log(`server started successfully at port ${serverPort}....`)
+);
+app.use('/', mockApi);

--- a/mock-server/package.json
+++ b/mock-server/package.json
@@ -10,7 +10,6 @@
   "author": "eagle",
   "license": "ISC",
   "dependencies": {
-    "body-parser": "^1.19.0",
     "cors": "^2.8.5",
     "express": "^4.17.1"
   }


### PR DESCRIPTION
Configured cors, so that app can connect to mock api. 
Deleted body-parser due to supporting its features by express from 4.16